### PR TITLE
chore: update readme, do not rely on msg being plaintext

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,8 @@ If need a different setup, don't hesitate con contact us on Discord. The Discord
 Run the following commands from the root folder:
 ```bash
 mkdir venv
-```
-```bash
 python3 -m venv venv/
-```
-```bash
 source venv/bin/activate
-```
-```bash
 ./venv/bin/python -m pip install -r requiremets.txt
 ```
 
@@ -31,8 +25,6 @@ source venv/bin/activate
 Run the following commands from the root folder:
 ```bash
 source venv/bin/activate
-```
-```bash
 ./venv/bin/python3 -m build
 ```
 
@@ -48,6 +40,26 @@ package to your local virtual env.
 
 ```bash
 ./venv/bin/python3 -m pip install dist/waku-0.0.1-cp310-cp310-linux_x86_64.whl
+```
+
+Current limitations of nwaku cbindings do not allow you to use DNS name in the multiaddress of a peer you want to connect to.
+Due to that, we recommend to run another local node to connect to other peers and then connect to this local node from the py-waku.
+
+```
+docker run -i -t -p 60000:60000 -p 9000:9000/udp harbor.status.im/wakuorg/nwaku:v0.24.0 --dns-discovery:true --dns-discovery-url:enrtree://ANEDLO25QVUGJOUTQFRYKWX6P4Z4GKVESBMHML7DZ6YK4LGS5FC5O@prod.wakuv2.nodes.status.im --discv5-discovery --rest --rest-address=0.0.0.0
+```
+
+Once this node is up, get the multiaddress
+
+```
+LOCAL_PEER_MA=$(curl http://127.0.0.1:8646/debug/v1/info | jq -r ".listenAddresses[0]")
+NODEKEY=$(openssl rand -hex 32)
+```
+
+You car run the `tests/waku_example.py` now as
+
+```
+./venv/bin/python3 tests/waku_example.py --peer ${LOCAL_PEER_MA} --key ${NODEKEY} -p 70000
 ```
 
 ## Update the libwaku.so library

--- a/tests/waku_example.py
+++ b/tests/waku_example.py
@@ -4,7 +4,12 @@ import waku
 
 def handle_event(ret, msg):
   if ret == 0: ## RET_OK
-    print("Ok event received: %s" % msg)
+    msgPlain = ""
+    try:
+      msgPlain = msg.decode('utf-8')
+    except:
+      msgPlain = "[binary content]"
+    print("Ok event received: %s" % msgPlain)
   else:
     print("Error: %s" % msg)
 
@@ -61,7 +66,7 @@ default_pubsub_topic = ""
 waku.waku_default_pubsub_topic(
     ctx,
     lambda ret, msg: (
-        globals().update(default_pubsub_topic = msg),
+        globals().update(default_pubsub_topic = msg.decode('utf-8')),
         print("Default pubsub topic: %s" % msg)))
 
 print("Bind addr: {}:{}".format(args.host, args.port))

--- a/waku/waku.py
+++ b/waku/waku.py
@@ -88,7 +88,7 @@ def process_callback(ret, char_p, len, callback):
   ## Second param - string. Gives detail of the feedback returned by the libwaku
 
   byte_string = ffi.buffer(char_p, len)[:]  # Use ffi.buffer to access memory directly
-  callback(ret, byte_string.decode('utf-8'))
+  callback(ret, byte_string)
 
 ##################################################################
 


### PR DESCRIPTION
This PR adds a bit of "how to run the example" into the README and fixes one issue I hit while running the example - when binary (protobuf encoded) messages appear, the py-waku will fail to decode them as utf-8, we should leave decoding to the app (callback) rather than assume plaintext is used